### PR TITLE
Added a function to error check spec files

### DIFF
--- a/lib/gulp_plugins/compiler.js
+++ b/lib/gulp_plugins/compiler.js
@@ -17,6 +17,49 @@ var rewriter = new Rewriter;
 // consts
 const PLUGIN_NAME = 'compiler';
 
+function specformatter(code)
+{
+  reasons = '';
+  // Take the code and prepend each line with a line number
+  numerate_code = code.split('\n');
+  for(var i = 0;i < numerate_code.length;i++){
+    numerate_code[i] = util.colors.gray((i+1)+': ')
+    + numerate_code[i] + '\n';
+  }
+  // Take each line number and count the terms
+  test_split = code.split("\n");
+  for(var i = 0;i < numerate_code.length;i++){
+      // if a line has quoted string, remove spaces between quotes
+      test_split[i] = test_split[i].replace(/'.*?'/, 'term');
+      terms = test_split[i].split(" ");
+      term_count = 0
+    for(var j = 0;j < terms.length;j++){
+      if (terms[j] != '') { term_count += 1; }
+   }
+   if (term_count == 2) { 
+    if (test_split[i].trim().substring(0,5) == 'visit'){}
+      // util.log("visit detected")
+    else if (test_split[i].trim().substring(0,5) == 'query'){}
+      // util.log("query detected")
+    else
+      reasons += "Two terms detected on line " + (i+1) + '\n';
+    }
+    else if (term_count == 4){
+      if (test_split[i].trim().substring(0,5) == 'after'){}
+      else
+        reasons += "Four terms detected on line " + (i+1) + '\n';
+    }
+    else if (term_count != 3){
+      if (test_split[i].trim() == ''){}
+      else
+        reasons += "Line " + (i+1) + ' violates rule of 3\n'; 
+    }
+   }
+
+
+  return [numerate_code.join("\0"), reasons]
+}
+
 function compile() {
 
   // creating a stream through which each file will pass
@@ -38,7 +81,14 @@ function compile() {
       iterator.initialize(tokens);
 
       util.log(util.colors.gray('Rewriting'), util.colors.yellow(name));
+      try{
       var script = rewriter.rewrite(iterator);
+    } catch (e)
+    {
+      util.log('Syntax error: \n' + specformatter(spec)[0]);
+      util.log('\nReasons: \n' + specformatter(spec)[1]);
+      var script = '// Syntax error, exiting \n slimer.exit();'
+    }
 
       file.contents = new Buffer(script);
     }


### PR DESCRIPTION
This change to compiler.js catches errors and generates a JS file for SlimerJS that simply exits the application.  When this kind of error happens, the terminal output shows the full text of the spec file, and tries to find lines that violate the rule of 3 (and lists them in a "Reasons" output).
